### PR TITLE
Fix CryptoCurrency association bug

### DIFF
--- a/app/models/crypto_currency.rb
+++ b/app/models/crypto_currency.rb
@@ -1,6 +1,9 @@
 class CryptoCurrency < ApplicationRecord
 	has_many :user_cryptos
-	has_many :users, through: :user_cryptos, foreign_key: 'crypto_id'
+        # Link crypto currencies to the users owning them through the join model
+        # The user_cryptos table already uses `crypto_currency_id` so we don't
+        # need to specify a foreign_key here (and using `crypto_id` was wrong)
+        has_many :users, through: :user_cryptos
 
 	def self.crypto_exists?(name, id)
 		unless CryptoCurrency.where(name: name).length == 0


### PR DESCRIPTION
## Summary
- fix `has_many :users` association for `CryptoCurrency`

## Testing
- `bundle exec rspec` *(fails: ruby-2.5.1 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68403f72db64832f8dfaa828c2dc3856